### PR TITLE
add throttling and cors locally

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -8,6 +8,17 @@ Globals:
         DEVENV: windows # macos | linux
 
 Resources:
+  ApiGatewayApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: local
+      Cors:
+        AllowMethods: "'OPTIONS,POST,GET'"
+        AllowHeaders: "'Content-Type'"
+        AllowOrigin: "'*'"
+        AllowCredentials: "'false'" # Disable credentials for CORS
+        # Add the following line to allow unauthenticated OPTIONS requests
+        ApiGatewayManagedCors: "'true'"
   PastebinFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -28,3 +39,8 @@ Resources:
           Properties:
             Path: /paste
             Method: post
+        cors:
+          Type: Api
+          Properties:
+            Path: /paste
+            Method: options

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -241,7 +241,7 @@ resource "aws_apigatewayv2_stage" "default" {
 
   default_route_settings {
     throttling_burst_limit = 5
-    throttling_rate_limit  = 30
+    throttling_rate_limit  = 5
   }
 
   route_settings {
@@ -252,8 +252,8 @@ resource "aws_apigatewayv2_stage" "default" {
 
   route_settings {
     route_key              = aws_apigatewayv2_route.post.route_key
-    throttling_burst_limit = 15
-    throttling_rate_limit  = 15
+    throttling_burst_limit = 5
+    throttling_rate_limit  = 5
   }
 
   depends_on = [aws_cloudwatch_log_group.api_gw]


### PR DESCRIPTION
- manages CORS locally (when testing with web browser)
- throttles endpoints more agressively