### PR TITLE
managing api and web returns properly

### DIFF
--- a/local/events/get-api.json
+++ b/local/events/get-api.json
@@ -1,0 +1,7 @@
+{
+    "queryStringParameters": {
+      "id": "f679e04f75bb74285359000765ea2af86adb198a"
+    },
+    "httpMethod": "GET",
+    "path": "/api"
+  }

--- a/local/events/get.json
+++ b/local/events/get.json
@@ -1,6 +1,10 @@
 {
   "queryStringParameters": {
-    "id": "f85d17b2104c753950f42cb20938637c15f4e8b4"
+    "id": "f679e04f75bb74285359000765ea2af86adb198a"
   },
-  "httpMethod": "GET"
+  "httpMethod": "GET",
+  "path": "/",
+  "headers": {
+    "User-Agent": "Mozilla"
+  }
 }

--- a/local/events/post.json
+++ b/local/events/post.json
@@ -1,4 +1,5 @@
 {
-  "content": "last antoher attempts",
-  "httpMethod": "POST"
+  "content": "examplary job",
+  "httpMethod": "POST",
+  "path": "/"
 }

--- a/openapi.yml
+++ b/openapi.yml
@@ -14,7 +14,7 @@ tags:
   - name: "pastes"
     description: "some strings a user wants to save for later"
 paths:
-  /paste:
+  /paste/api:
     get:
       summary: Retrieve a paste by ID
       description: open endpoint to retrieve a paste by ID

--- a/template.yml
+++ b/template.yml
@@ -34,10 +34,20 @@ Resources:
           Properties:
             Path: /paste
             Method: get
+        GetApiPaste:
+          Type: Api
+          Properties:
+            Path: /paste/api
+            Method: get
         CreatePaste:
           Type: Api
           Properties:
             Path: /paste
+            Method: post
+        CreateApiPaste:
+          Type: Api
+          Properties:
+            Path: /paste/api
             Method: post
         cors:
           Type: Api

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -253,26 +253,11 @@ resource "aws_apigatewayv2_integration" "apigw_lambda" {
   integration_method = "POST"
 }
 
-resource "aws_apigatewayv2_route" "get" {
-  for_each = toset("GET /paste", "GET /paste/api")
+resource "aws_apigatewayv2_route" "routes" {
+  for_each = { for route in var.routes : route => route }
 
   route_key = each.value
   api_id    = aws_apigatewayv2_api.http_lambda.id
-  target    = "integrations/${aws_apigatewayv2_integration.apigw_lambda.id}"
-}
-
-resource "aws_apigatewayv2_route" "post" {
-  for_each = toset("POST /paste", "POST /paste/api")
-
-  route_key = each.value
-  api_id    = aws_apigatewayv2_api.http_lambda.id
-  target    = "integrations/${aws_apigatewayv2_integration.apigw_lambda.id}"
-}
-
-resource "aws_apigatewayv2_route" "options" {
-  api_id = aws_apigatewayv2_api.http_lambda.id
-
-  route_key = "OPTIONS /paste"
   target    = "integrations/${aws_apigatewayv2_integration.apigw_lambda.id}"
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -234,7 +234,7 @@ resource "aws_apigatewayv2_stage" "default" {
     for_each = aws_apigatewayv2_route.read
 
     content {
-      route_key              = lookup(each.value, "route_key", "")
+      route_key              = route_settings.value.route_key
       throttling_burst_limit = 5
       throttling_rate_limit  = 2
     }
@@ -244,7 +244,7 @@ resource "aws_apigatewayv2_stage" "default" {
     for_each = aws_apigatewayv2_route.write
 
     content {
-      route_key              = lookup(each.value, "route_key", "")
+      route_key              = route_settings.value.route_key
       throttling_burst_limit = 2
       throttling_rate_limit  = 1
     }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -254,16 +254,18 @@ resource "aws_apigatewayv2_integration" "apigw_lambda" {
 }
 
 resource "aws_apigatewayv2_route" "get" {
-  api_id = aws_apigatewayv2_api.http_lambda.id
+  for_each = toset("GET /paste", "GET /paste/api")
 
-  route_key = "GET /paste"
+  route_key = each.value
+  api_id    = aws_apigatewayv2_api.http_lambda.id
   target    = "integrations/${aws_apigatewayv2_integration.apigw_lambda.id}"
 }
 
 resource "aws_apigatewayv2_route" "post" {
-  api_id = aws_apigatewayv2_api.http_lambda.id
+  for_each = toset("POST /paste", "POST /paste/api")
 
-  route_key = "POST /paste"
+  route_key = each.value
+  api_id    = aws_apigatewayv2_api.http_lambda.id
   target    = "integrations/${aws_apigatewayv2_integration.apigw_lambda.id}"
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -231,13 +231,13 @@ resource "aws_apigatewayv2_stage" "default" {
   }
 
   route_settings {
-    route_key              = aws_apigatewayv2_route.get.route_key
+    route_key              = aws_apigatewayv2_route.read.route_key
     throttling_burst_limit = 5
     throttling_rate_limit  = 2
   }
 
   route_settings {
-    route_key              = aws_apigatewayv2_route.post.route_key
+    route_key              = aws_apigatewayv2_route.write.route_key
     throttling_burst_limit = 2
     throttling_rate_limit  = 1
   }
@@ -253,8 +253,16 @@ resource "aws_apigatewayv2_integration" "apigw_lambda" {
   integration_method = "POST"
 }
 
-resource "aws_apigatewayv2_route" "routes" {
-  for_each = { for route in var.routes : route => route }
+resource "aws_apigatewayv2_route" "read" {
+  for_each = { for route in var.routes_read : route => route }
+
+  route_key = each.value
+  api_id    = aws_apigatewayv2_api.http_lambda.id
+  target    = "integrations/${aws_apigatewayv2_integration.apigw_lambda.id}"
+}
+
+resource "aws_apigatewayv2_route" "write" {
+  for_each = { for route in var.routes_write : route => route }
 
   route_key = each.value
   api_id    = aws_apigatewayv2_api.http_lambda.id

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -27,5 +27,5 @@ output "api_gateway_arn" {
 }
 
 output "api_gateway_routes" {
-  value = aws_apigatewayv2_route.read.route_key
+  value = aws_apigatewayv2_route.read
 }

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -26,6 +26,6 @@ output "api_gateway_arn" {
   value = aws_apigatewayv2_api.http_lambda.arn
 }
 
-output "api_gateway_route" {
-  value = aws_apigatewayv2_route.get.route_key
+output "api_gateway_routes" {
+  value = aws_apigatewayv2_route.routes.route_key
 }

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -27,5 +27,5 @@ output "api_gateway_arn" {
 }
 
 output "api_gateway_routes" {
-  value = aws_apigatewayv2_route.routes.route_key
+  value = aws_apigatewayv2_route.read.route_key
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,9 @@
+variable "routes" {
+  type        = list(string)
+  description = "list of API routes to be configured in API Gateway"
+  default     = ["GET /paste", "GET /paste/api", "POST /paste", "POST /paste/api", "OPTIONS /paste"]
+}
+
 variable "region" {
   type    = string
   default = "ca-central-1"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,7 +1,13 @@
-variable "routes" {
-  type        = list(string)
-  description = "list of API routes to be configured in API Gateway"
-  default     = ["GET /paste", "GET /paste/api", "POST /paste", "POST /paste/api", "OPTIONS /paste"]
+variable "routes_read" {
+  type        = set(string)
+  description = "list of API GET routes to be configured in API Gateway"
+  default     = ["GET /paste", "GET /paste/api", "OPTIONS /paste"]
+}
+
+variable "routes_write" {
+  type        = set(string)
+  description = "list of API POST routes to be configured in API Gateway"
+  default     = ["POST /paste", "POST /paste/api"]
 }
 
 variable "region" {


### PR DESCRIPTION
- adding an endpoint (get and post) for /paste/api
- they are the ones documented in openapi
- bringing back a html formated return when request comes from a web browser