### PR TITLE
adding route for list paste ids

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -161,7 +161,8 @@ resource "aws_iam_policy" "lambda_exec_role" {
             "Action": [
                 "dynamodb:GetItem",
                 "dynamodb:PutItem",
-                "dynamodb:UpdateItem"
+                "dynamodb:UpdateItem",
+                "dynamodb:Scan"
             ],
             "Resource": "arn:aws:dynamodb:*:*:table/${var.dynamodb_table}"
         },

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,7 +1,7 @@
 variable "routes_read" {
   type        = set(string)
   description = "list of API GET routes to be configured in API Gateway"
-  default     = ["GET /paste", "GET /paste/api", "GET /paste/api/pastes","OPTIONS /paste"]
+  default     = ["GET /paste", "GET /paste/api", "GET /paste/api/pastes", "OPTIONS /paste"]
 }
 
 variable "routes_write" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,7 +1,7 @@
 variable "routes_read" {
   type        = set(string)
   description = "list of API GET routes to be configured in API Gateway"
-  default     = ["GET /paste", "GET /paste/api", "OPTIONS /paste"]
+  default     = ["GET /paste", "GET /paste/api", "GET /paste/api/pastes","OPTIONS /paste"]
 }
 
 variable "routes_write" {
@@ -50,6 +50,7 @@ variable "cors_allow_origins" {
 variable "notification_email" {
   type      = string
   sensitive = true
+  default   = "maximebonin@outlook.com"
 }
 
 variable "zipped_files" {


### PR DESCRIPTION
- registering `/api/pastes` endpoint to Api Gateway
- giving Lambda Role permission to Scan DynamoDB