### PR TITLE
Addingclientid

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -3,7 +3,7 @@ import json
 import os
 
 from model import PasteDataAware
-from api_handler import ApiHandler, hash_value
+from api_handler import ApiHandler
 from dynamodb import DB
 import logging
 import hashlib

--- a/src/app.py
+++ b/src/app.py
@@ -33,10 +33,17 @@ def _dynamodb_endpoint_by_os(os: str):
 
 
 def get_pastes_handler(event, context, db: DB):
-    client_ip = event["requestContext"]["identity"]["sourceIp"]
+    query_params = event.get("queryStringParameters", {})
+    has_client_id = any(key == "client_id" for key in query_params)
+
+    client_id = ""
+    if has_client_id:
+        client_id = query_params.get("client_id")
+    else:
+        client_id = event["requestContext"]["identity"]["sourceIp"]
 
     api_handler = ApiHandler(db=db, base_url=os.environ.get("BASE_URL"))
-    paste_urls = api_handler.latest_pastes_urls(client_identifier=client_ip)
+    paste_urls = api_handler.latest_pastes_urls(client_identifier=client_id)
 
     return {
         "statusCode": 200,
@@ -53,7 +60,8 @@ def get_pastes_handler(event, context, db: DB):
 
 def get_handler(event, context, db: DB, is_web_browser: bool = False):
     try:
-        paste = PasteDataAware(db=db, id=event["queryStringParameters"]["id"])
+        id = event["queryStringParameters"]["id"]
+        paste = PasteDataAware(db=db, id=id)
         content = paste.read()
     except:
         logger.error(f"GET-failed to retrieve requested paste-id {id}")
@@ -115,7 +123,13 @@ def post_handler(event, context, db: DB):
         logger.warning(f'POST- unable to load content from event["body"])["content"]')
         content = event["content"]
 
-    paste = PasteDataAware(content=content, db=db, client_identifier=client_ip)
+    client_id = ""
+    try:
+        client_id = json.loads(event["body"], strict=False)["client_id"]
+    except:
+        client_id = client_ip
+
+    paste = PasteDataAware(content=content, db=db, client_identifier=client_id)
 
     try:
         id = paste.insert()

--- a/src/app.py
+++ b/src/app.py
@@ -3,9 +3,17 @@ import json
 import os
 
 from model import PasteDataAware
-from api_handler import ApiHandler
+from api_handler import ApiHandler, hash_value
 from dynamodb import DB
 import logging
+import hashlib
+
+
+def hash_value(value: str, encoding: str = "utf-8") -> str:
+    value_bytes = str(value).encode(encoding=encoding)
+    hash_object = hashlib.md5()
+    hash_object.update(value_bytes)
+    return hash_object.hexdigest()
 
 
 logger = logging.getLogger()
@@ -34,16 +42,15 @@ def _dynamodb_endpoint_by_os(os: str):
 
 def get_pastes_handler(event, context, db: DB):
     query_params = event.get("queryStringParameters", {})
-    has_client_id = any(key == "client_id" for key in query_params)
 
     client_id = ""
-    if has_client_id:
+    try:
         client_id = query_params.get("client_id")
-    else:
+    except:
         client_id = event["requestContext"]["identity"]["sourceIp"]
 
     api_handler = ApiHandler(db=db, base_url=os.environ.get("BASE_URL"))
-    paste_urls = api_handler.latest_pastes_urls(client_identifier=client_id)
+    paste_urls = api_handler.latest_pastes_urls(client_identifier=hash_value(client_id))
 
     return {
         "statusCode": 200,
@@ -129,7 +136,9 @@ def post_handler(event, context, db: DB):
     except:
         client_id = client_ip
 
-    paste = PasteDataAware(content=content, db=db, client_identifier=client_id)
+    paste = PasteDataAware(
+        content=content, db=db, client_identifier=hash_value(client_id)
+    )
 
     try:
         id = paste.insert()

--- a/template.yml
+++ b/template.yml
@@ -6,7 +6,7 @@ Globals:
     Environment:
       Variables:
         DEVENV: windows # macos | linux
-
+        BASE_URL: "http://localhost:3000"
 Resources:
   ApiGatewayApi:
     Type: AWS::Serverless::Api

--- a/template.yml
+++ b/template.yml
@@ -39,6 +39,16 @@ Resources:
           Properties:
             Path: /paste/api
             Method: get
+        GetApiPastes:
+          Type: Api
+          Properties:
+            Path: /paste/api/pastes
+            Method: get
+          cors:
+            Type: Api
+            Properties:
+              Path: /paste
+              Method: options
         CreatePaste:
           Type: Api
           Properties:


### PR DESCRIPTION
- in order to link pastes to a user Pastebin is using a 'client_id'.  By default it is the user IP address. but User can also provide their own client_id in the POST payload