### PR TITLE
make paste last only 1 hour with dynamodb ttl

### DIFF
--- a/src/abstract.py
+++ b/src/abstract.py
@@ -55,6 +55,8 @@ class Paste:
         if client_identifier is not None:
             self._metadata[KEY_CLIENT_ID] = client_identifier
 
+        self._ttl_timestamp = int(time.time()) + 3600  # one hour
+
     def dict(self) -> Dict:
 
         return {
@@ -64,6 +66,7 @@ class Paste:
             "encoding": DEFAULT_ENCODING,
             "created_time_epoch": self._unix_timestamp,
             "metadata": self._metadata,
+            "ttl": self._ttl_timestamp,
         }
 
     def get_client_identifier(self):

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -41,6 +41,10 @@ resource "aws_dynamodb_table" "paste" {
     name = "id"
     type = "S"
   }
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
 }
 
 # #========================================================================


### PR DESCRIPTION
1- Terraform: enable TTL on dynamodb table
2- python: Paste Abtract class: adding a concept of TTL .   TTL value gets posted among paste content in dynamodb

dynamodb is supposed to have a background task that will delete the Item when TTL is past due

https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html?icmpid=docs_dynamodb_help_panel_hp_ttl