### PR TITLE
use a tf filehash function instead of string hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,7 @@ src.zip
 
 terraform-provider*
 .terraform*
+!.terraformignore
 *.zip
 
 creds

--- a/terraform/.terraformignore
+++ b/terraform/.terraformignore
@@ -1,0 +1,6 @@
+# Ignore everything by default
+*
+
+# Negate ignore for zip files used in Lambda functions and layers
+!lambda.zip
+!layer.zip

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -86,6 +86,12 @@ resource "aws_lambda_layer_version" "dependencies_layer" {
   layer_name          = "python-layer"
   source_code_hash    = filebase64sha256(data.archive_file.layer_zip.output_path)
   compatible_runtimes = [var.python_runtime]
+
+  lifecycle {
+    ignore_changes = [
+      source_code_hash,
+    ]
+  }
 }
 
 data "archive_file" "lambda_zip" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -84,7 +84,7 @@ data "archive_file" "layer_zip" {
 resource "aws_lambda_layer_version" "dependencies_layer" {
   filename            = var.zipped_files["layer"]
   layer_name          = "python-layer"
-  source_code_hash    = base64sha256(data.archive_file.layer_zip.output_path)
+  source_code_hash    = filebase64sha256(data.archive_file.layer_zip.output_path)
   compatible_runtimes = [var.python_runtime]
 }
 
@@ -115,7 +115,7 @@ resource "aws_lambda_function" "apigw_lambda_ddb" {
   runtime = var.python_runtime
   handler = "app.lambda_handler"
 
-  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
+  source_code_hash = filebase64sha256(data.archive_file.lambda_zip.output_path)
 
   role = aws_iam_role.lambda_exec.arn
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -128,7 +128,12 @@ resource "aws_lambda_function" "apigw_lambda_ddb" {
       BASE_URL      = var.api_base_url
     }
   }
-  layers     = [aws_lambda_layer_version.dependencies_layer.arn]
+  layers = [aws_lambda_layer_version.dependencies_layer.arn]
+  lifecycle {
+    ignore_changes = [
+      layers,
+    ]
+  }
   depends_on = [aws_cloudwatch_log_group.lambda_logs]
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -86,12 +86,6 @@ resource "aws_lambda_layer_version" "dependencies_layer" {
   layer_name          = "python-layer"
   source_code_hash    = filebase64sha256(data.archive_file.layer_zip.output_path)
   compatible_runtimes = [var.python_runtime]
-
-  lifecycle {
-    ignore_changes = [
-      source_code_hash,
-    ]
-  }
 }
 
 data "archive_file" "lambda_zip" {


### PR DESCRIPTION
solves issue #50 if no change in code, then dont deploy a new lambda or lambda layer

what's the fix?
- decouple the Lambda code from the layer (if the layer change, the lambda must not necessarilty change)

- since dependencies versions are not pinned, we gonna have that layer deployed because always latest

