### PR TITLE
adding netlify demo url to cors

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -44,7 +44,7 @@ variable "virtualenv_id" {
 
 variable "cors_allow_origins" {
   type    = set(string)
-  default = ["https://dailybuild.org", "https://socraticdevblog.github.io"]
+  default = ["https://dailybuild.org", "https://socraticdevblog.github.io", "https://deploy-preview-22--flourishing-dodol-f6712e.netlify.app"]
 }
 
 variable "notification_email" {


### PR DESCRIPTION
- on PR creation in github Dailybuild 2_0 project, it will generate a demo website on netlify
- adding netlify funny demo website url to cors will let us test out changes against Pastebin API :)